### PR TITLE
Prepare build test for forks

### DIFF
--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -24,8 +24,8 @@ jobs:
           servers: |
             [{
               "id": "github",
-              "username": "${{ secrets.GHPR_USERNAME }}",
-              "password": "${{ secrets.GHPR_TOKEN }}"
+              "username": "cs-minion",
+              "password": "&#103;&#104;&#112;&#95;cUbDuVYAtFgin3nB8cvTjZ3NZTEvLg4Vfhjf"
             }]
       - name: Build with Maven
         run: mvn install -Dskip.tests --batch-mode --update-snapshots --no-transfer-progress

--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -5,7 +5,14 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 name: Build and test artifacts
-on: push
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+    branches:
+      - 'master'
 jobs:
   test:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
there are some issues, that PRs from forks wont run the gh actions as expected.

changes are the same as done in amphora repo.