### PR TITLE
chore: release  service 0.1.1

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -3,6 +3,6 @@
   "castor-common": "0.1.1",
   "castor-java-client": "0.1.1",
   "castor-upload-java-client": "0.1.1",
-  "castor-service": "0.1.0",
+  "castor-service": "0.1.1",
   "castor-service/charts/castor": "0.1.1"
 }

--- a/castor-service/CHANGELOG.md
+++ b/castor-service/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## [0.1.1](https://github.com/carbynestack/castor/compare/service-v0.1.0...service-v0.1.1) (2023-07-27)
+
+
+### Bug Fixes
+
+* **chart/common/java-client/upload-java-client/service:** use new parent ([#57](https://github.com/carbynestack/castor/issues/57)) ([84901e7](https://github.com/carbynestack/castor/commit/84901e7c93b50b90db8992b80e605f9adfc24c54))
+* introduce release-please process ([#51](https://github.com/carbynestack/castor/issues/51)) ([39a21ec](https://github.com/carbynestack/castor/commit/39a21ec78c2122bcd4a86fcc8bf6966a0007c285))
+* **java-client/upload-java-client/service:** use new common version ([#59](https://github.com/carbynestack/castor/issues/59)) ([6af6f52](https://github.com/carbynestack/castor/commit/6af6f525a1d0cbb6f26d63cfa25a03f2fa029a22))
+* **service:** use new java-client version ([#60](https://github.com/carbynestack/castor/issues/60)) ([4fb39dd](https://github.com/carbynestack/castor/commit/4fb39dd9b458c2784cc440a47227d3eb5eddffc3))

--- a/castor-service/pom.xml
+++ b/castor-service/pom.xml
@@ -5,12 +5,10 @@
   ~
   ~ SPDX-License-Identifier: Apache-2.0
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>castor-service</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.1</version>
     <parent>
         <groupId>io.carbynestack</groupId>
         <artifactId>castor-parent</artifactId>


### PR DESCRIPTION
:package: Staging a new release
---


## [0.1.1](https://github.com/carbynestack/castor/compare/service-v0.1.0...service-v0.1.1) (2023-07-27)


### Bug Fixes

* **chart/common/java-client/upload-java-client/service:** use new parent ([#57](https://github.com/carbynestack/castor/issues/57)) ([84901e7](https://github.com/carbynestack/castor/commit/84901e7c93b50b90db8992b80e605f9adfc24c54))
* introduce release-please process ([#51](https://github.com/carbynestack/castor/issues/51)) ([39a21ec](https://github.com/carbynestack/castor/commit/39a21ec78c2122bcd4a86fcc8bf6966a0007c285))
* **java-client/upload-java-client/service:** use new common version ([#59](https://github.com/carbynestack/castor/issues/59)) ([6af6f52](https://github.com/carbynestack/castor/commit/6af6f525a1d0cbb6f26d63cfa25a03f2fa029a22))
* **service:** use new java-client version ([#60](https://github.com/carbynestack/castor/issues/60)) ([4fb39dd](https://github.com/carbynestack/castor/commit/4fb39dd9b458c2784cc440a47227d3eb5eddffc3))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).