### PR TITLE
chore: release  parent 0.1.1

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "castor-parent": "0.1.0",
+  "castor-parent": "0.1.1",
   "castor-common": "0.1.0",
   "castor-java-client": "0.1.0",
   "castor-upload-java-client": "0.1.0",

--- a/castor-parent/CHANGELOG.md
+++ b/castor-parent/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [0.1.1](https://github.com/carbynestack/castor/compare/parent-v0.1.0...parent-v0.1.1) (2023-07-27)
+
+
+### Bug Fixes
+
+* introduce release-please process ([#51](https://github.com/carbynestack/castor/issues/51)) ([39a21ec](https://github.com/carbynestack/castor/commit/39a21ec78c2122bcd4a86fcc8bf6966a0007c285))

--- a/castor-parent/pom.xml
+++ b/castor-parent/pom.xml
@@ -5,13 +5,11 @@
   ~
   ~ SPDX-License-Identifier: Apache-2.0
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>castor-parent</artifactId>
     <groupId>io.carbynestack</groupId>
-    <version>0.1.0</version>
+    <version>0.1.1</version>
     <packaging>pom</packaging>
     <licenses>
         <license>


### PR DESCRIPTION
:package: Staging a new release
---


## [0.1.1](https://github.com/carbynestack/castor/compare/parent-v0.1.0...parent-v0.1.1) (2023-07-27)


### Bug Fixes

* introduce release-please process ([#51](https://github.com/carbynestack/castor/issues/51)) ([39a21ec](https://github.com/carbynestack/castor/commit/39a21ec78c2122bcd4a86fcc8bf6966a0007c285))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).