### PR TITLE
chore: release  common 0.1.1

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
   "castor-parent": "0.1.1",
-  "castor-common": "0.1.0",
+  "castor-common": "0.1.1",
   "castor-java-client": "0.1.0",
   "castor-upload-java-client": "0.1.0",
   "castor-service": "0.1.0",

--- a/castor-common/CHANGELOG.md
+++ b/castor-common/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## [0.1.1](https://github.com/carbynestack/castor/compare/common-v0.1.0...common-v0.1.1) (2023-07-27)
+
+
+### Bug Fixes
+
+* **chart/common/java-client/upload-java-client/service:** use new parent ([#57](https://github.com/carbynestack/castor/issues/57)) ([84901e7](https://github.com/carbynestack/castor/commit/84901e7c93b50b90db8992b80e605f9adfc24c54))
+* introduce release-please process ([#51](https://github.com/carbynestack/castor/issues/51)) ([39a21ec](https://github.com/carbynestack/castor/commit/39a21ec78c2122bcd4a86fcc8bf6966a0007c285))

--- a/castor-common/pom.xml
+++ b/castor-common/pom.xml
@@ -5,12 +5,10 @@
   ~
   ~ SPDX-License-Identifier: Apache-2.0
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>castor-common</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.1</version>
     <repositories>
         <repository>
             <snapshots>


### PR DESCRIPTION
:package: Staging a new release
---


## [0.1.1](https://github.com/carbynestack/castor/compare/common-v0.1.0...common-v0.1.1) (2023-07-27)


### Bug Fixes

* **chart/common/java-client/upload-java-client/service:** use new parent ([#57](https://github.com/carbynestack/castor/issues/57)) ([84901e7](https://github.com/carbynestack/castor/commit/84901e7c93b50b90db8992b80e605f9adfc24c54))
* introduce release-please process ([#51](https://github.com/carbynestack/castor/issues/51)) ([39a21ec](https://github.com/carbynestack/castor/commit/39a21ec78c2122bcd4a86fcc8bf6966a0007c285))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).