### PR TITLE
chore: release  chart 0.1.1

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -4,5 +4,5 @@
   "castor-java-client": "0.1.0",
   "castor-upload-java-client": "0.1.0",
   "castor-service": "0.1.0",
-  "castor-service/charts/castor": "0.1.0"
+  "castor-service/charts/castor": "0.1.1"
 }

--- a/castor-service/charts/castor/CHANGELOG.md
+++ b/castor-service/charts/castor/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [0.1.1](https://github.com/carbynestack/castor/compare/chart-v0.1.0...chart-v0.1.1) (2023-07-27)
+
+
+### Bug Fixes
+
+* **chart/common/java-client/upload-java-client/service:** use new parent ([#57](https://github.com/carbynestack/castor/issues/57)) ([84901e7](https://github.com/carbynestack/castor/commit/84901e7c93b50b90db8992b80e605f9adfc24c54))

--- a/castor-service/charts/castor/Chart.yaml
+++ b/castor-service/charts/castor/Chart.yaml
@@ -1,13 +1,14 @@
 apiVersion: v1
 appVersion: "1.0"
-description: A Helm chart for creating a Carbyne Stack Castor tuple storage and management service.
+description: A Helm chart for creating a Carbyne Stack Castor tuple storage and
+  management service.
 name: castor
-version: 0.1.0
+version: 0.1.1
 keywords:
-- carbyne stack
-- castor
+  - carbyne stack
+  - castor
 home: https://carbynestack.io
 sources:
-- https://github.com/carbynestack/castor
+  - https://github.com/carbynestack/castor
 maintainers:
-- name: CarbyneStack.io
+  - name: CarbyneStack.io


### PR DESCRIPTION
:package: Staging a new release
---


## [0.1.1](https://github.com/carbynestack/castor/compare/chart-v0.1.0...chart-v0.1.1) (2023-07-27)


### Bug Fixes

* **chart/common/java-client/upload-java-client/service:** use new parent ([#57](https://github.com/carbynestack/castor/issues/57)) ([84901e7](https://github.com/carbynestack/castor/commit/84901e7c93b50b90db8992b80e605f9adfc24c54))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).