### PR TITLE
chore: release  chart 0.2.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -4,5 +4,5 @@
   "castor-java-client": "0.1.1",
   "castor-upload-java-client": "0.1.1",
   "castor-service": "0.1.1",
-  "castor-service/charts/castor": "0.1.1"
+  "castor-service/charts/castor": "0.2.0"
 }

--- a/castor-service/charts/castor/CHANGELOG.md
+++ b/castor-service/charts/castor/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.2.0](https://github.com/carbynestack/castor/compare/chart-v0.1.1...chart-v0.2.0) (2023-08-08)
+
+
+### ⚠ BREAKING CHANGES
+
+* **chart:** remove redis deployment from castor chart ([#61](https://github.com/carbynestack/castor/issues/61))
+
+### Features
+
+* **chart:** remove redis deployment from castor chart ([#61](https://github.com/carbynestack/castor/issues/61)) ([d299bf8](https://github.com/carbynestack/castor/commit/d299bf88df5777cc6718f2587cd4025dd34ba295))
+
 ## [0.1.1](https://github.com/carbynestack/castor/compare/chart-v0.1.0...chart-v0.1.1) (2023-07-27)
 
 

--- a/castor-service/charts/castor/Chart.yaml
+++ b/castor-service/charts/castor/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for creating a Carbyne Stack Castor tuple storage and
   management service.
 name: castor
-version: 0.1.1
+version: 0.2.0
 keywords:
   - carbyne stack
   - castor


### PR DESCRIPTION
:package: Staging a new release
---


## [0.2.0](https://github.com/carbynestack/castor/compare/chart-v0.1.1...chart-v0.2.0) (2023-08-08)


### ⚠ BREAKING CHANGES

* **chart:** remove redis deployment from castor chart ([#61](https://github.com/carbynestack/castor/issues/61))

### Features

* **chart:** remove redis deployment from castor chart ([#61](https://github.com/carbynestack/castor/issues/61)) ([d299bf8](https://github.com/carbynestack/castor/commit/d299bf88df5777cc6718f2587cd4025dd34ba295))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).