### PR TITLE
chore: release  chart 0.3.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -4,5 +4,5 @@
   "castor-java-client": "0.1.1",
   "castor-upload-java-client": "0.1.1",
   "castor-service": "0.1.1",
-  "castor-service/charts/castor": "0.2.0"
+  "castor-service/charts/castor": "0.3.0"
 }

--- a/castor-service/charts/castor/CHANGELOG.md
+++ b/castor-service/charts/castor/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.3.0](https://github.com/carbynestack/castor/compare/chart-v0.2.0...chart-v0.3.0) (2024-10-09)
+
+
+### Features
+
+* **charts:** add redis reservationTimeout ([#63](https://github.com/carbynestack/castor/issues/63)) ([eead173](https://github.com/carbynestack/castor/commit/eead173d1c28d51dff3aa677f76da2cd74bc81c2))
+
 ## [0.2.0](https://github.com/carbynestack/castor/compare/chart-v0.1.1...chart-v0.2.0) (2023-08-08)
 
 

--- a/castor-service/charts/castor/Chart.yaml
+++ b/castor-service/charts/castor/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for creating a Carbyne Stack Castor tuple storage and
   management service.
 name: castor
-version: 0.2.0
+version: 0.3.0
 keywords:
   - carbyne stack
   - castor


### PR DESCRIPTION
:package: Staging a new release
---


## [0.3.0](https://github.com/carbynestack/castor/compare/chart-v0.2.0...chart-v0.3.0) (2024-10-09)


### Features

* **charts:** add redis reservationTimeout ([#63](https://github.com/carbynestack/castor/issues/63)) ([eead173](https://github.com/carbynestack/castor/commit/eead173d1c28d51dff3aa677f76da2cd74bc81c2))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).