### PR TITLE
chore: release  parent 0.2.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "castor-parent": "0.1.1",
+  "castor-parent": "0.2.0",
   "castor-common": "0.1.1",
   "castor-java-client": "0.1.1",
   "castor-upload-java-client": "0.1.1",

--- a/castor-parent/CHANGELOG.md
+++ b/castor-parent/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.2.0](https://github.com/carbynestack/castor/compare/parent-v0.1.1...parent-v0.2.0) (2024-10-08)
+
+
+### Features
+
+* **parent:** upgrade dependencies ([#66](https://github.com/carbynestack/castor/issues/66)) ([d48e035](https://github.com/carbynestack/castor/commit/d48e0350216a20ecab5e72cf1703a0ab96030391))
+
 ## [0.1.1](https://github.com/carbynestack/castor/compare/parent-v0.1.0...parent-v0.1.1) (2023-07-27)
 
 

--- a/castor-parent/pom.xml
+++ b/castor-parent/pom.xml
@@ -9,7 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>castor-parent</artifactId>
     <groupId>io.carbynestack</groupId>
-    <version>0.1.1</version>
+    <version>0.2.0</version>
     <packaging>pom</packaging>
     <licenses>
         <license>


### PR DESCRIPTION
:package: Staging a new release
---


## [0.2.0](https://github.com/carbynestack/castor/compare/parent-v0.1.1...parent-v0.2.0) (2024-10-08)


### Features

* **parent:** upgrade dependencies ([#66](https://github.com/carbynestack/castor/issues/66)) ([d48e035](https://github.com/carbynestack/castor/commit/d48e0350216a20ecab5e72cf1703a0ab96030391))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).