### PR TITLE
chore: release  upload-java-client 0.2.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,7 +2,7 @@
   "castor-parent": "0.2.0",
   "castor-common": "0.2.0",
   "castor-java-client": "0.2.0",
-  "castor-upload-java-client": "0.1.1",
+  "castor-upload-java-client": "0.2.0",
   "castor-service": "0.1.1",
   "castor-service/charts/castor": "0.2.0"
 }

--- a/castor-upload-java-client/CHANGELOG.md
+++ b/castor-upload-java-client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.2.0](https://github.com/carbynestack/castor/compare/upload-java-client-v0.1.1...upload-java-client-v0.2.0) (2024-10-09)
+
+
+### Features
+
+* **castor-common/castor-java-client/castor-service/castor-upload-java-client:** upgrade parent ([#68](https://github.com/carbynestack/castor/issues/68)) ([c712935](https://github.com/carbynestack/castor/commit/c71293591f5ff69f12cd063b0c7c900d17b7a78a))
+
 ## [0.1.1](https://github.com/carbynestack/castor/compare/upload-java-client-v0.1.0...upload-java-client-v0.1.1) (2023-07-27)
 
 

--- a/castor-upload-java-client/pom.xml
+++ b/castor-upload-java-client/pom.xml
@@ -8,7 +8,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>castor-upload-java-client</artifactId>
-    <version>0.1.1</version>
+    <version>0.2.0</version>
     <parent>
         <groupId>io.carbynestack</groupId>
         <artifactId>castor-parent</artifactId>


### PR DESCRIPTION
:package: Staging a new release
---


## [0.2.0](https://github.com/carbynestack/castor/compare/upload-java-client-v0.1.1...upload-java-client-v0.2.0) (2024-10-09)


### Features

* **castor-common/castor-java-client/castor-service/castor-upload-java-client:** upgrade parent ([#68](https://github.com/carbynestack/castor/issues/68)) ([c712935](https://github.com/carbynestack/castor/commit/c71293591f5ff69f12cd063b0c7c900d17b7a78a))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).